### PR TITLE
Feature: hidden endpoints

### DIFF
--- a/src/GrommetSwagger.js
+++ b/src/GrommetSwagger.js
@@ -10,6 +10,7 @@ import Endpoints from './Endpoints';
 import Endpoint from './Endpoint';
 import Execute from './Execute';
 import Loading from './Loading';
+import { filterHiddenPaths } from './utils';
 
 const THEMES = {
   hpe: hpeTheme,
@@ -57,6 +58,7 @@ export default class GrommetSwagger extends Component {
     fetch(url, { method: 'GET' })
       .then(response => response.text())
       .then(text => jsyaml.load(text))
+      .then(filterHiddenPaths)
       .then((data) => {
         document.title = data.info.title;
         this.setState({

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,3 +42,17 @@ export const definitionToJson = (data, def, visited = {}) => {
 
 export const searchString = obj =>
   Object.keys(obj).map(name => `${name}=${encodeURIComponent(obj[name])}`).join('&');
+
+export const filterHidden = paths =>
+  Object.keys(paths).reduce((visibleDefs, path) => {
+    const visibleRoutes = Object.keys(paths[path]).filter(method => !paths[path][method].tags || !paths[path][method].tags.includes('hidden'));
+    return {
+      ...visibleDefs,
+      ...visibleRoutes.length ? {
+        [path]: visibleRoutes.reduce((methods, method) =>
+          ({ ...methods, [method]: paths[path][method] }), {}),
+      } : {},
+    };
+  }, {});
+
+export const filterHiddenPaths = data => ({ ...data, paths: filterHidden(data.paths) });


### PR DESCRIPTION
 add ability to filter out pre-release endpoints

- define `tags: 'hidden'` to hide endpoints
- if all endpoints in a route are hidden, the entire route does not render

example definition

```yaml
/appliances:
    get:
      ...
      summary: NOT IMPLEMENTED
      tags:
        - hidden
```

resolves #13

(merging this PR will also merge in #12)