### PR TITLE
Fix unintended markdown em styling. Closes 15 and 16

### DIFF
--- a/src/Definition.js
+++ b/src/Definition.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Heading, Markdown, Responsive, Text } from 'grommet';
+import { sanitizeForMarkdown } from './utils';
 import Nav from './Nav';
 
 const isRequired = (name, definitions) => definitions.find(singleName => name === singleName);
@@ -42,8 +43,7 @@ export default class Definition extends Component {
                     </Box>
                     <Box basis='medium' pad={{ right: 'medium', bottom: 'medium' }}>
                       <Markdown>
-                        {(definitions.properties[property].description || '')
-                          .replace(new RegExp('</BR>', 'gi'), '\n\n')}
+                        {sanitizeForMarkdown(definitions.properties[property].description)}
                       </Markdown>
                       {definitions.properties[property].type ? <Text color='dark-5'>{definitions.properties[property].type}</Text> : null}
                       {isRequired(property, definitions.required) ? <Text color='dark-5'>required</Text> : null}

--- a/src/Endpoint.js
+++ b/src/Endpoint.js
@@ -5,7 +5,7 @@ import hljs from 'highlight.js';
 import { RoutedAnchor, Box, Heading, Markdown, Responsive, RoutedButton, Text } from 'grommet';
 import { LinkNext } from 'grommet-icons';
 import Nav from './Nav';
-import { definitionToJson, searchString } from './utils';
+import { definitionToJson, sanitizeForMarkdown, searchString } from './utils';
 
 class Schema extends Component {
   componentDidMount() {
@@ -48,8 +48,7 @@ const Parameter = ({ data, parameter, first }) => (
       </Box>
       <Box basis='medium' pad={{ right: 'medium' }}>
         <Markdown>
-          {(parameter.description || '')
-            .replace(new RegExp('</BR>', 'gi'), '\n\n')}
+          {sanitizeForMarkdown(parameter.description)}
         </Markdown>
         {parameter.type !== 'string' ? <Text color='dark-5'>{parameter.type}</Text> : null}
         {parameter.required ? <Text color='dark-5'>required</Text> : null}
@@ -90,8 +89,7 @@ const Response = ({
       </Box>
       <Box flex={true} pad={{ horizontal: 'medium' }} margin={{ vertical: 'small' }}>
         <Markdown>
-          {(response.description || '')
-            .replace(new RegExp('</BR>', 'gi'), '\n\n')}
+          {sanitizeForMarkdown(response.description)}
         </Markdown>
       </Box>
     </Box>
@@ -167,12 +165,12 @@ class Method extends Component {
           </Heading>
           { method && method.summary &&
             <Markdown>
-              {(method.summary).replace(new RegExp('</BR>', 'gi'), '\n\n')}
+              {sanitizeForMarkdown(method.summary)}
             </Markdown>
           }
           { method && method.description &&
             <Markdown>
-              {(method.description).replace(new RegExp('</BR>', 'gi'), '\n\n')}
+              {sanitizeForMarkdown(method.description)}
             </Markdown>
           }
         </Box>

--- a/src/Endpoints.js
+++ b/src/Endpoints.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Anchor, Box, Button, Heading, Markdown, Responsive } from 'grommet';
 import { Eject as UnloadIcon } from 'grommet-icons';
+import { sanitizeForMarkdown } from './utils';
 import Nav from './Nav';
 
 export default class extends Component {
@@ -32,7 +33,7 @@ export default class extends Component {
               <Heading level={1} margin='none'><strong>{data.info.title}</strong></Heading>
               <Box pad={{ vertical: 'large' }}>
                 <Markdown>
-                  {(data.info.description || '').replace(new RegExp('</BR>', 'gi'), '\n\n')}
+                  {sanitizeForMarkdown(data.info.description)}
                 </Markdown>
               </Box>
             </Box>

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,3 +42,23 @@ export const definitionToJson = (data, def, visited = {}) => {
 
 export const searchString = obj =>
   Object.keys(obj).map(name => `${name}=${encodeURIComponent(obj[name])}`).join('&');
+
+export const sanitizeForMarkdown = (stringForMd) => {
+  if (!stringForMd) {
+    return '';
+  }
+  let mdStringWithBreaks = stringForMd.replace(new RegExp('</BR>', 'gi'), '\n\n');
+  mdStringWithBreaks = mdStringWithBreaks.replace(new RegExp('\\n\\n', 'gi'), ' \n\n ');
+  console.log(JSON.stringify(mdStringWithBreaks));
+  const mdArray = mdStringWithBreaks.split(' ');
+  const cleanMdArray = mdArray.map((md) => {
+    // Avoid errors in situations like this - '_this should all style_, rest of the string...'
+    const actualString = md.replace(new RegExp('[.,]', 'g'), '');
+    if (actualString.indexOf('_') > 1 && actualString.indexOf('_') !== actualString.length - 1) {
+      // This is an underscore that is not preceeded by a space and should not be em styled.
+      return md.replace(new RegExp('_', 'gi'), '\\_');
+    }
+    return md;
+  });
+  return cleanMdArray.join(' ');
+};


### PR DESCRIPTION
markdown-to-jsx does not correctly detect em styling, if a variable of `foo_bar_baz` is passed to the parser it will style it as foo<em>bar</em>baz. I've written a utility to correctly style ems in accordance to Github's markdown parsing. Essentially the utility detects where the underscore is and will escape the character if it is not supposed to be styled.

I've tested this with SimpliVity's and OneSphere's swagger files and everything seems to be rendering correctly.