### PR TITLE
support rendering on IE11

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: /markdown-to-jsx/,
         loader: 'babel-loader',
       },
     ],


### PR DESCRIPTION
babel-loader needs to also transpile the source in node_modules down to es5

:white_check_mark: Windows10: Firefox
:white_check_mark: Windows10: Chrome
:white_check_mark: Windows10: Edge
:white_check_mark: Windows10: IE11

resolves #19