### PR TITLE
Downgrade query-string to fix issue in ie11 to fix OneSphere issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "history": "^4.7.2",
     "js-yaml": "^3.10.0",
     "prop-types": "^15.6.0",
-    "query-string": "^6.0.0",
+    "query-string": "^5.0.0",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-router-dom": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6996,20 +6996,14 @@ qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-query-string@^5.0.1:
+query-string@^5.0.0, query-string@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
   dependencies:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
-
-query-string@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
-  dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -8090,10 +8084,6 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Downgrade query-string to fix issue in ie11 to fix OneSphere issue

The `query-string` package says that v6 is not compatible with ie11 and to downgrade to v5 if you need to support ie11. (https://github.com/sindresorhus/query-string\#install).  In order to use this project, we need it to be compatible with ie11, so I have downgraded the library.  

I am not sure how to test this and am not seeing there is CI available, so will ask that the reviewer please test and report any issues.

See: https://jira.hpcloud.net/browse/PLAT-214